### PR TITLE
a rich terminal backend example

### DIFF
--- a/backend/terminado/example.py
+++ b/backend/terminado/example.py
@@ -1,0 +1,61 @@
+import os.path
+from pprint import pprint
+import tornado.web
+import tornado.ioloop
+# This demo requires tornado_xstatic and XStatic-term.js
+import tornado_xstatic
+
+import terminado
+import re
+
+STATIC_DIR = os.path.join(os.path.dirname(terminado.__file__), "_static")
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+class TerminalPageHandler(tornado.web.RequestHandler):
+    def get(self):
+        return self.render("sockterm.html", static=self.static_url,
+                           xstatic=self.application.settings['xstatic_url'],
+                           ws_url_path="/websocket")
+
+
+
+class PlainTermSocket(terminado.TermSocket):
+    """Plaintext version of terminado textsocket""" 
+
+    def on_pty_read(self, text):
+        # remove unsupported OCR command (will fix later)
+        text = re.sub("\x1b]\d;.*((\x1b\\\\)|(\x07))", "", text)
+        # temporary workaround for issue #2
+        text = re.sub("\x1b\[0(\d+)", "\x1b[\\1", text)
+        self.write_message(text)
+
+    def send_json_message(self, msg):
+        pass
+
+    def on_message(self, message):
+        self.terminal.ptyproc.write(message)
+
+
+if __name__ == '__main__':
+    import sys
+    cmd = sys.argv[1:]
+    print(f"Running terminado server, with command {cmd}")
+
+    term_manager = terminado.SingleTermManager(shell_command=[cmd])
+    handlers = [
+                (r"/websocket", PlainTermSocket,
+                     {'term_manager': term_manager}),
+                (r"/", TerminalPageHandler)
+               ]
+    app = tornado.web.Application(handlers, static_path=STATIC_DIR,
+
+                                  template_path=TEMPLATE_DIR,
+                      xstatic_url = tornado_xstatic.url_maker('/xstatic/'))
+    # Serve at http://localhost:8000/ N.B. Leaving out 'localhost' here will
+    # work, but it will listen on the public network interface as well.
+    # Given what terminado does, that would be rather a security hole.
+    app.listen(8000, 'localhost')
+    try:
+        tornado.ioloop.IOLoop.instance().start()
+    finally:
+        term_manager.shutdown()

--- a/backend/terminado/requirements.txt
+++ b/backend/terminado/requirements.txt
@@ -1,0 +1,9 @@
+terminado==0.9.1  # CAREFUL : js file may be missing in some dists : https://github.com/jupyter/terminado/issues/83
+tornado==6.1
+tornado-xstatic==0.2
+XStatic==1.0.2
+XStatic-term.js==0.0.7.0
+
+# possible interactive python repls for testing the terminal
+# ptpython==3.0.7
+# ipython==7.19.0

--- a/backend/terminado/single_xterm.py
+++ b/backend/terminado/single_xterm.py
@@ -1,0 +1,56 @@
+"""A single common terminal for all websockets.
+"""
+import tornado.web
+# This demo requires tornado_xstatic and XStatic-term.js
+import tornado_xstatic
+
+from terminado import TermSocket, SingleTermManager
+
+import os.path
+import webbrowser
+import tornado.ioloop
+import terminado
+
+STATIC_DIR = os.path.join(os.path.dirname(terminado.__file__), "_static")
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+def run_and_show_browser(url, term_manager):
+    loop = tornado.ioloop.IOLoop.instance()
+    loop.add_callback(webbrowser.open, url)
+    try:
+        loop.start()
+    except KeyboardInterrupt:
+        print(" Shutting down on SIGINT")
+    finally:
+        term_manager.shutdown()
+        loop.close()
+
+class TerminalPageHandler(tornado.web.RequestHandler):
+    def get(self):
+        return self.render("xterm.html", static=self.static_url,
+                           xstatic=self.application.settings['xstatic_url'],
+                           ws_url_path="/websocket")
+
+def main(cmd):
+    term_manager = SingleTermManager(shell_command=cmd)
+    handlers = [
+                (r"/websocket", TermSocket,
+                     {'term_manager': term_manager}),
+                (r"/", TerminalPageHandler),
+                (r"/xstatic/(.*)", tornado_xstatic.XStaticFileHandler,
+                     {'allowed_modules': ['termjs']})
+               ]
+    app = tornado.web.Application(handlers, static_path=STATIC_DIR,
+                      template_path=TEMPLATE_DIR,
+                      xstatic_url = tornado_xstatic.url_maker('/xstatic/'))
+    app.listen(8765, 'localhost')
+    run_and_show_browser("http://localhost:8765/", term_manager)
+
+
+if __name__ == '__main__':
+
+    import sys
+    cmd = sys.argv[1:]
+    print(f"Running terminado server, with command {cmd}")
+
+    main(cmd)

--- a/backend/terminado/templates/sockterm.html
+++ b/backend/terminado/templates/sockterm.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <script src="https://cdn.jsdelivr.net/gh/wsowens/sockterm@1.0.7/dist/sockterm-element.min.js" type="application/javascript"></script>
+  <style>
+    body {
+      /* using Bliss for that comfy XP vibe */
+      background-image: url(https://i.imgur.com/VvNhMb0.jpg);
+      background-size: 100% auto;
+    }
+    main {
+      display: flex;
+      flex-direction: column;
+      width: 50%;
+      margin: auto 25%;
+      align-items: center;
+      text-align: center;
+    }
+    h1 {
+      font-family: monospace;
+      background-color: #111111;
+      color: #00AA00;
+    }
+    h2 {
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <!-- I tried to make this as easy as possible...-->
+  <main>
+    <h1 style="width: 9em;">sockterm 🧦🖥</h1>
+    <h2 style="font-style: italic;">Connect to WebSocket servers like it's 1979!</h2>
+    <sock-term></sock-term>
+  </main>
+</body>
+</html>

--- a/backend/terminado/templates/xterm.html
+++ b/backend/terminado/templates/xterm.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<head>
+<meta charset="UTF-8"> 
+<title>pyxterm</title>
+<!--
+  pyxterm: Basic Python socket implementation for term.js
+
+  Example template
+  Modified by: R. Saravanan <sarava@sarava.net> 2014
+  Original Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
+-->
+<style>
+  html {
+    background: #555;
+  }
+
+  h1 {
+    margin-bottom: 20px;
+    font: 20px/1.5 sans-serif;
+  }
+</style>
+<script src="{{ xstatic('termjs', 'term.js') }}"></script>
+<script src="{{ static('terminado.js') }}"></script>
+<script>
+window.onload = function() {
+    // Test size: 25x80
+    var termRowHeight = 0.0 + 1.00*document.getElementById("dummy-screen").offsetHeight / 25;
+    var termColWidth = 0.0 + (1.02*document.getElementById("dummy-screen-rows").offsetWidth / 80);
+    document.getElementById("dummy-screen").setAttribute("style", "display: none");
+
+    var protocol = (window.location.protocol.indexOf("https") === 0) ? "wss" : "ws";
+    var ws_url = protocol+"://"+window.location.host+ "{{ws_url_path}}";
+    
+    function calculate_size(element) {
+        var rows = Math.max(2, Math.floor(element.innerHeight/termRowHeight)-1);
+        var cols = Math.max(3, Math.floor(element.innerWidth/termColWidth)-1);
+        console.log("resize:", termRowHeight, termColWidth, element.innerHeight,
+                                        element.innerWidth, rows, cols);
+        return {rows: rows, cols: cols};
+    }
+
+    size = calculate_size(window);
+    var terminal = make_terminal(document.body, size, ws_url);
+    
+    window.onresize = function() { 
+      var geom = calculate_size(window);
+      terminal.term.resize(geom.cols, geom.rows);
+      terminal.socket.send(JSON.stringify(["set_size", geom.rows, geom.cols,
+                                window.innerHeight, window.innerWidth]));
+    };
+};
+</script>
+</head>
+<body>
+<!-- test size: 25x80 -->
+<pre id="dummy-screen" style="visibility:hidden; border: white solid 5px; font-family: &quot;DejaVu Sans Mono&quot;, &quot;Liberation Mono&quot;, monospace; font-size: 11px;">0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+0
+1
+2
+3
+<span id="dummy-screen-rows" style="visibility:hidden;">01234567890123456789012345678901234567890123456789012345678901234567890123456789</span>
+</pre>
+</body>


### PR DESCRIPTION
I am here attempting to have a webbrowser securely connecting to a terminal via websocket, and get a repl running...
There is one with xterm and another with sockterm for comparison.

Current issues with this backend example code :
 
- https://github.com/jupyter/terminado/issues/83
- https://github.com/jupyter/terminado/issues/82
- https://github.com/gvalkov/tornado-http-auth/issues/9

Also various issues to solve on the sockterm side.
- https://github.com/wsowens/sockterm/issues/3
- https://github.com/wsowens/sockterm/issues/4
